### PR TITLE
fix: removes twitter from ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,4 @@ jobs:
       - uses: actions/setup-node@v2
       - run: npm ci
       - run: npm run lint
-      - env:
-          TWITTER_TEST_ACCESS_TOKEN: ${{ secrets.TWITTER_TEST_ACCESS_TOKEN }}
-          TWITTER_TEST_ACCESS_TOKEN_SECRET: ${{ secrets.TWITTER_TEST_ACCESS_TOKEN_SECRET }}
-          TWITTER_TEST_CONSUMER_API_KEY: ${{ secrets.TWITTER_TEST_CONSUMER_API_KEY }}
-          TWITTER_TEST_CONSUMER_SECRET: ${{ secrets.TWITTER_TEST_CONSUMER_SECRET }}
-        run: npm run test
+      - run: npm run test-exclude-twitter

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "destiny-insights-bot",
       "version": "1.43.14",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "eslint .",
     "fix-lint": "eslint . --fix",
     "test": "nyc ava",
+    "test-exclude-twitter": "nyc ava --match='!*Twitter*'",
     "build": "npm install --production && rm -rf build && mkdir build && zip -r -q -x='*media*' -x='package-lock.json' -x='*terraform*' -x=*coverage* -x='*.md' -x='LICENSE' -x='*build*' -x='*test*' -x='*.DS_Store*' -x='*.nyc_output*' -x='*.git*' -x='*.nycrc' -x='*.eslintrc.js' -x='release.config.js' -x='commitlint.config.js' build/destiny-insights-bot.zip . && du -sh build",
     "deploy": "aws lambda update-function-code --function-name=destiny-insights-bot --zip-file=fileb://build/destiny-insights-bot.zip --region=us-east-1 1> /dev/null",
     "ci": "npm run lint && npm run test",


### PR DESCRIPTION
## What

fix: removes twitter from ci

## Why

The twitter integration test requires a twitter auth, which is secure and can not be trusted to run on forks, including dependabot.